### PR TITLE
chore(ci): add Linux arm64 build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -9,9 +11,10 @@ builds:
       - darwin_amd64
       - darwin_arm64
       - linux_amd64
+      - linux_arm64
       - windows_amd64
 
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]


### PR DESCRIPTION
Updated .goreleaser.yml to:
- Add support for Linux ARM64 builds.
- Fix deprecation warnings on .goreleaser.yml by:
  - Updating the version on the file. see: https://goreleaser.com/errors/version/?h=version
  - Replacing `format` with `formats: ['zip']` see: https://goreleaser.com/deprecations#archivesformat_overridesformat